### PR TITLE
Add arguments for controlling output

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,41 @@ follows:
 clang-17 -fplugin=build/lib/libc_taint.so -fsyntax-only some/program.c
 ```
 
+### Taint analyzer arguments
+
+By default, the taint analyzer will only print the program's entry and exit
+functions. You can modify this output with the following arguments:
+
+| Argument               | Description                                    |
+|------------------------|------------------------------------------------|
+| `--print-block-labels` | Print blocks and their labels.                 |
+| `--print-init`         | Print blocks init labels.                      |
+| `--print-finals`       | Print block final labels.                      |
+| `--print-flow`         | Print block flows.                             |
+| `--print-kill`         | Print each block's set of killed variables.    |
+| `--print-gen`          | Print each block's set of generated variables. |
+| `--print-entry`        | Print the entry function for each block.       |
+| `--print-exit`         | Print the exit function for each block.        |
+
+For example:
+
+```bash
+clang-17 -fplugin=build/lib/libc_taint.so -fsyntax-only some/program.c -Xclang -plugin-arg-c_taint_analyzer -Xclang --print-block-labels
+```
+
+The above command tells the taint analyzer to print the program's blocks and
+labels as well.
+
+You can also prepend an argument with `no` to tell the taint analyzer not to
+print a field in the output. For example:
+
+```bash
+clang-17 -fplugin=build/lib/libc_taint.so -fsyntax-only some/program.c -Xclang -plugin-arg-c_taint_analyzer -Xclang --no-print-entry
+```
+
+The above command tells the taint analyzer not to print the entry function for
+each block.
+
 ## Development
 
 We recommend downloading the [`clangd`](https://clangd.llvm.org/installation)

--- a/include/c_taint/Analyses.hh
+++ b/include/c_taint/Analyses.hh
@@ -55,11 +55,11 @@ void ComputeLeastFixedPoint(Block *B, EntryFunction &Entry, ExitFunction &Exit,
 void PrintBlockLabels(const BlockLabelMap &BL, const clang::PrintingPolicy &PP);
 
 /* Prints the init labels for each block in a table. */
-void PrintInitLabelsTable(const Block *B, InitFunction &Init,
+void PrintInitTable(const Block *B, InitFunction &Init,
                           const clang::PrintingPolicy &PP);
 
 /* Prints the finals labels for each block in a table. */
-void PrintFinalsLabelsTable(const Block *B, FinalsFunction &Finals,
+void PrintFinalsTable(const Block *B, FinalsFunction &Finals,
                             const clang::PrintingPolicy &PP);
 
 /* Prints the flow for each block in a table. */

--- a/include/c_taint/CTaintASTConsumer.hh
+++ b/include/c_taint/CTaintASTConsumer.hh
@@ -6,6 +6,22 @@
 namespace c_taint {
 class CTaintASTConsumer : public clang::ASTConsumer {
     public:
+        bool ShouldPrintBlockLabels = false;
+        bool ShouldPrintInitTable = false;
+        bool ShouldPrintFinalsTable = false;
+        bool ShouldPrintFlowTable = false;
+        bool ShouldPrintKillTable = false;
+        bool ShouldPrintGenTable = false;
+        bool ShouldPrintEntryTable = false;
+        bool ShouldPrintExitTable = false;
+
+        CTaintASTConsumer(bool ShouldPrintBlockLabels,
+                          bool ShouldPrintInitTable,
+                          bool ShouldPrintFinalsTable,
+                          bool ShouldPrintFlowTable, bool ShouldPrintKillTable,
+                          bool ShouldPrintGenTable, bool ShouldPrintEntryTable,
+                          bool ShouldPrintExitTable);
+
         void HandleTranslationUnit(clang::ASTContext &Ctx) override;
 };
 }

--- a/lib/Analyses.cc
+++ b/lib/Analyses.cc
@@ -450,7 +450,7 @@ void PrintBlockLabels(const BlockLabelMap &BL,
         }
 }
 
-void PrintInitLabelsTable(const Block *B, InitFunction &Init,
+void PrintInitTable(const Block *B, InitFunction &Init,
                           const clang::PrintingPolicy &PP) {
         if (Init.contains(B)) {
                 auto L = Init.at(B);
@@ -458,11 +458,11 @@ void PrintInitLabelsTable(const Block *B, InitFunction &Init,
                 llvm::outs() << " " << L << "\n";
         }
         for (auto Child : B->children()) {
-                PrintInitLabelsTable(Child, Init, PP);
+                PrintInitTable(Child, Init, PP);
         }
 }
 
-void PrintFinalsLabelsTable(const Block *B, FinalsFunction &Finals,
+void PrintFinalsTable(const Block *B, FinalsFunction &Finals,
                             const clang::PrintingPolicy &PP) {
         if (Finals.contains(B)) {
                 auto Ls = Finals.at(B);
@@ -479,7 +479,7 @@ void PrintFinalsLabelsTable(const Block *B, FinalsFunction &Finals,
                 llvm::outs() << "}\n";
         }
         for (auto Child : B->children()) {
-                PrintFinalsLabelsTable(Child, Finals, PP);
+                PrintFinalsTable(Child, Finals, PP);
         }
 }
 

--- a/lib/CTaintPluginASTAction.cc
+++ b/lib/CTaintPluginASTAction.cc
@@ -10,6 +10,14 @@ namespace c_taint {
 class PluginASTAction : public clang::PluginASTAction {
     public:
         bool Unparse = false;
+        bool ShouldPrintBlockLabels = false;
+        bool ShouldPrintInitTable = false;
+        bool ShouldPrintFinalsTable = false;
+        bool ShouldPrintFlowTable = false;
+        bool ShouldPrintKillTable = false;
+        bool ShouldPrintGenTable = false;
+        bool ShouldPrintEntryTable = true;
+        bool ShouldPrintExitTable = true;
 
         PluginASTAction()
                 : clang::PluginASTAction() {
@@ -24,6 +32,30 @@ class PluginASTAction : public clang::PluginASTAction {
                        std::vector<std::string> const &Args) override {
                 for (auto &Arg : Args) {
                         Unparse |= Arg == "--unparse";
+                        ShouldPrintBlockLabels |= Arg == "--print-block-labels";
+                        ShouldPrintInitTable |= Arg == "--print-init";
+                        ShouldPrintFinalsTable |= Arg == "--print-finals";
+                        ShouldPrintFlowTable |= Arg == "--print-flow";
+                        ShouldPrintKillTable |= Arg == "--print-kill";
+                        ShouldPrintGenTable |= Arg == "--print-gen";
+                        ShouldPrintEntryTable |= Arg == "--print-entry";
+                        ShouldPrintExitTable |= Arg == "--print-exit";
+
+                        ShouldPrintBlockLabels &=
+                                (1 - (Arg == "--no-print-block-labels"));
+                        ShouldPrintInitTable &=
+                                (1 - (Arg == "--no-print-init"));
+                        ShouldPrintFinalsTable &=
+                                (1 - (Arg == "--no-print-finals"));
+                        ShouldPrintFlowTable &=
+                                (1 - (Arg == "--no-print-flow"));
+                        ShouldPrintKillTable &=
+                                (1 - (Arg == "--no-print-kill"));
+                        ShouldPrintGenTable &= (1 - (Arg == "--no-print-gen"));
+                        ShouldPrintEntryTable &=
+                                (1 - (Arg == "--no-print-entry"));
+                        ShouldPrintExitTable &=
+                                (1 - (Arg == "--no-print-exit"));
                 }
                 return true;
         }
@@ -36,7 +68,11 @@ class PluginASTAction : public clang::PluginASTAction {
                 if (Unparse) {
                         return std::make_unique<UnparserASTConsumer>();
                 }
-                return std::make_unique<CTaintASTConsumer>();
+                return std::make_unique<CTaintASTConsumer>(
+                        ShouldPrintBlockLabels, ShouldPrintInitTable,
+                        ShouldPrintFinalsTable, ShouldPrintFlowTable,
+                        ShouldPrintKillTable, ShouldPrintGenTable,
+                        ShouldPrintEntryTable, ShouldPrintExitTable);
         }
 
         clang::PluginASTAction::ActionType getActionType() override {


### PR DESCRIPTION
- Add arguments for controlling the taint analyzer's output to the plugin action and the AST consumer.
- Add instructions on how to use these arguments to the readme.